### PR TITLE
Able to specify which rds instance you want to connect to 

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -50,22 +50,32 @@ var awsConnectElasticSearchCmd = &cobra.Command{
 }
 
 var awsConnectPostgresCmd = &cobra.Command{
-	Use:   "postgres <profile>",
+	Use:   "postgres <profile> <instance>",
 	Short: "creates an ssh tunnel to postgres RDS instance on AWS",
 	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 1 {
-			return errors.New("profile name can't contain spaces")
+		if len(args) > 2 {
+			return errors.New("too many arguments")
 		}
 
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		profile := "default"
-		if len(args) > 0 {
+		var instance *string
+		if len(args) == 0 {
 			profile = args[0]
+			instance = nil
+		}
+		if len(args) == 1 {
+			profile = args[0]
+			instance = nil
+		}
+		if len(args) == 2 {
+			profile = args[0]
+			instance = &args[1]
 		}
 
-		err := aws.ConnectPostgres("eu-west-1", profile)
+		err := aws.ConnectPostgres("eu-west-1", profile, instance)
 		util.HandleFatalError(err)
 	},
 }

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -94,12 +94,12 @@ func ConnectPostgres(region string, profile string, instanceName *string) error 
 		return err
 	}
 
-	logger.Info("Finding running worker instanceName")
+	logger.Info("Finding running worker instance")
 	workerId, err := connection.EC2.GetRunningWorkerInstanceId()
 	if err != nil {
 		return err
 	}
-	logger.Info("Using worker instanceName: " + workerId)
+	logger.Info("Using worker instance: " + workerId)
 
 	logger.Info("Finding RDS instances")
 	instances, err := connection.RDS.GetInstances()

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -77,7 +77,7 @@ func ConnectElasticSearch(region string, profile string) error {
 	return cmdAwaitInterrupt(cmd, errCh,"Shutting down SSH tunnel")
 }
 
-func ConnectPostgres(region string, profile string) error {
+func ConnectPostgres(region string, profile string, instanceName *string) error {
 	err := os.Setenv("AWS_PROFILE", profile)
 	if err != nil {
 		return err
@@ -94,12 +94,12 @@ func ConnectPostgres(region string, profile string) error {
 		return err
 	}
 
-	logger.Info("Finding running worker instance")
+	logger.Info("Finding running worker instanceName")
 	workerId, err := connection.EC2.GetRunningWorkerInstanceId()
 	if err != nil {
 		return err
 	}
-	logger.Info("Using worker instance: " + workerId)
+	logger.Info("Using worker instanceName: " + workerId)
 
 	logger.Info("Finding RDS instances")
 	instances, err := connection.RDS.GetInstances()
@@ -107,8 +107,25 @@ func ConnectPostgres(region string, profile string) error {
 		return err
 	}
 
-	logger.Info("Finding endpoint for RDS instance: " + instances[0])
-	endpoint, err := connection.RDS.GetEndpoint(instances[0])
+	instance := instances[0]
+	if instanceName != nil {
+		instanceExists := false
+		for _, remoteInstance := range instances {
+			if remoteInstance == *instanceName {
+				instanceExists = true
+				break
+			}
+		}
+
+		if instanceExists {
+			instance = *instanceName
+		} else {
+			return errors.New("No instance "  + *instanceName + " available.")
+		}
+	}
+
+	logger.Info("Finding endpoint for RDS instanceName: " + instance)
+	endpoint, err := connection.RDS.GetEndpoint(instance)
 
 	pemFilePath, err := getCertificatePath()
 	if err != nil {

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -124,7 +124,7 @@ func ConnectPostgres(region string, profile string, instanceName *string) error 
 		}
 	}
 
-	logger.Info("Finding endpoint for RDS instanceName: " + instance)
+	logger.Info("Finding endpoint for RDS instance: " + instance)
 	endpoint, err := connection.RDS.GetEndpoint(instance)
 
 	pemFilePath, err := getCertificatePath()


### PR DESCRIPTION
This code fixes an issue where Hippo would connect to the first instance returned from AWS.

The argument for instance is not mandatory, so this is backwards compatible with any scripts or users refusing to change usage behaviour.